### PR TITLE
Add simple dinner suggestion CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
-# what-s-for-dinner
-what's for dinner?
+# What's for Dinner
+
+This is a simple interactive command-line app. Select the ingredients you have and it will tell you which dinners you can make.
+
+## Setup
+
+Install dependencies:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+
+Run the app with:
+
+```bash
+python -m dinner_app.main
+```
+
+You will be presented with a checklist of ingredients. After selecting what you have, the app lists any matching dinner options.

--- a/dinner_app/main.py
+++ b/dinner_app/main.py
@@ -1,0 +1,24 @@
+import questionary
+from .recipes import get_available_ingredients, possible_dinners
+
+
+def main() -> None:
+    ingredients = list(get_available_ingredients())
+    answer = questionary.checkbox(
+        "Select the ingredients you have:", choices=ingredients
+    ).ask()
+    if answer is None:
+        print("No ingredients selected.")
+        return
+    owned = set(answer)
+    dinners = possible_dinners(owned)
+    if dinners:
+        print("You can make:")
+        for dinner in dinners:
+            print(f"- {dinner}")
+    else:
+        print("No dinners match your ingredients.")
+
+
+if __name__ == "__main__":
+    main()

--- a/dinner_app/recipes.py
+++ b/dinner_app/recipes.py
@@ -1,0 +1,19 @@
+RECIPES = {
+    "Spaghetti Bolognese": ["spaghetti", "ground beef", "tomato sauce"],
+    "Grilled Cheese": ["bread", "cheese", "butter"],
+    "Chicken Salad": ["chicken", "lettuce", "tomato"],
+    "Veggie Stir Fry": ["broccoli", "carrot", "soy sauce"],
+}
+
+
+def get_available_ingredients() -> set:
+    """Return a set of all ingredients used in recipes."""
+    ingredients = set()
+    for items in RECIPES.values():
+        ingredients.update(items)
+    return ingredients
+
+
+def possible_dinners(owned: set) -> list:
+    """Return a list of recipes that can be made with the owned ingredients."""
+    return [name for name, reqs in RECIPES.items() if set(reqs).issubset(owned)]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+questionary
+pytest
+flake8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203,W503

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # noqa: E402
+
+from dinner_app.recipes import possible_dinners  # noqa: E402
+
+
+def test_possible_dinners():
+    owned = {"spaghetti", "ground beef", "tomato sauce"}
+    assert possible_dinners(owned) == ["Spaghetti Bolognese"]


### PR DESCRIPTION
## Summary
- create dinner recipes and interactive CLI to pick them
- document usage in README
- lint and test via flake8/pytest

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6887d8fc8da083298c8c48897b85eee5