### PR TITLE
Add recipe detail popups

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,4 +21,5 @@ python -m dinner_app.main
 ```
 
 A window will open displaying the available ingredients and possible dinners.
+Double-click a dinner to view its ingredients.
 Use the **Add Recipe** button to contribute new ideas.

--- a/dinner_app/gui.py
+++ b/dinner_app/gui.py
@@ -6,6 +6,7 @@ from tkinter import ttk, messagebox, simpledialog
 from .recipes import (
     add_recipe,
     get_available_ingredients,
+    get_recipe_ingredients,
     possible_dinners,
 )
 
@@ -36,6 +37,7 @@ class DinnerApp(tk.Tk):
         self.dinner_var = tk.StringVar(value=[])
         self.dinner_list = tk.Listbox(dinner_box, listvariable=self.dinner_var)
         self.dinner_list.pack(fill="both", expand=True)
+        self.dinner_list.bind("<Double-1>", self.show_recipe)
 
         add_btn = ttk.Button(right, text="Add Recipe", command=self.add_recipe_dialog)
         add_btn.pack(pady=5)
@@ -59,6 +61,20 @@ class DinnerApp(tk.Tk):
     def update_dinners(self, *args) -> None:
         dinners = possible_dinners(self.owned_ingredients())
         self.dinner_var.set(sorted(dinners))
+
+    def show_recipe(self, event) -> None:
+        """Display the ingredients for the selected recipe."""
+
+        selection = self.dinner_list.curselection()
+        if not selection:
+            return
+        name = self.dinner_list.get(selection[0])
+        ingredients = get_recipe_ingredients(name)
+        if ingredients is None:
+            messagebox.showerror("Error", f"Recipe for {name} not found.")
+            return
+        msg = f"Ingredients for {name}:\n" + "\n".join(f"- {i}" for i in ingredients)
+        messagebox.showinfo(name, msg)
 
     def add_recipe_dialog(self) -> None:
         name = simpledialog.askstring("New Recipe", "Recipe name:", parent=self)

--- a/dinner_app/recipes.py
+++ b/dinner_app/recipes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 RECIPES_FILE = Path(__file__).with_name("recipes.json")
 
@@ -27,6 +27,12 @@ _recipes = load_recipes()
 def get_recipes() -> Dict[str, List[str]]:
     """Return the in-memory recipes dictionary."""
     return _recipes
+
+
+def get_recipe_ingredients(name: str) -> Optional[List[str]]:
+    """Return a list of ingredients for ``name`` if it exists."""
+
+    return _recipes.get(name)
 
 
 def add_recipe(name: str, ingredients: List[str], *, persist: bool = True) -> None:

--- a/tests/test_recipes_extended.py
+++ b/tests/test_recipes_extended.py
@@ -13,3 +13,9 @@ def test_add_recipe_without_persist():
     dinners = recipes.possible_dinners({"test ingredient"})
     assert dinners == ["Test Dish"]
     recipes.reset_recipes()
+
+
+def test_get_recipe_ingredients():
+    recipes.reset_recipes()
+    ingredients = recipes.get_recipe_ingredients("Grilled Cheese")
+    assert ingredients == ["bread", "cheese", "butter"]


### PR DESCRIPTION
## Summary
- add new `get_recipe_ingredients` helper
- show recipe details on double-click in GUI
- document new feature in README
- test getting recipe ingredients

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6887e05bf1f483298f74a7f7f8173755